### PR TITLE
Fix broken links to source files in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,11 +109,11 @@ The core of FSharp.Json library is located in single [Core.fs file][core].
 
 ## Documentation
 
-This document describe all details of FSharp.Json library. The source code also has thorough documentation in comments to main types. Each feature of FSharp.Json is thoroughly covered by [unit tests](tests/FSharp.Json.Tests).
+This document describe all details of FSharp.Json library. The source code also has thorough documentation in comments to main types. Each feature of FSharp.Json is thoroughly covered by [unit tests](FSharp.Json.Tests).
 
 ## API Overview
 
-Most of API functions are defined in [Json module](src/FSharp.Json/Interface.fs).
+Most of API functions are defined in [Json module](FSharp.Json/Interface.fs).
 
 Easiest way to serialize is to call `Json.serialize` function.
 It serializes any supported F# type to string containing JSON.
@@ -129,11 +129,11 @@ Whenever custom configuration should be used following functions are useful:
  * `Json.serializeEx`
  * `Json.deserializeEx<'T>` 
 
-Prefix `Ex` stands for "extended". Both of these functions take [JsonConfig](src/FSharp.Json/InterfaceTypes.fs) instance as a first parameter.
+Prefix `Ex` stands for "extended". Both of these functions take [JsonConfig](FSharp.Json/InterfaceTypes.fs) instance as a first parameter.
 
 #### Configuration
 
-[JsonConfig](src/FSharp.Json/InterfaceTypes.fs) represents global configuration of serialization.
+[JsonConfig](FSharp.Json/InterfaceTypes.fs) represents global configuration of serialization.
 There's convenient way to override default configuration by using `JsonConfig.create` function.
 All parameters of the function are optional and those that are provided override default values.
 
@@ -145,7 +145,7 @@ Some products like [Apache Spark](https://spark.apache.org/) require unformatted
 It is usefull to produce unformatted single line JSON in some other scenarios.
 There is a function to produce unformatted JSON: `Json.serializeU`.
 `U` stands for "unformatted". It has the same signature as `Json.serialize` function.
-The function is a shorthand to using `unformatted` member on [JsonConfig](src/FSharp.Json/InterfaceTypes.fs).
+The function is a shorthand to using `unformatted` member on [JsonConfig](FSharp.Json/InterfaceTypes.fs).
 
 ## Supported Types
 
@@ -389,8 +389,8 @@ let deserialized = Json.deserialize<TheNumberEnum> json
 
 #### Customizing enum serialization
 
-EnumValue member of [JsonField](src/FSharp.Json/InterfaceTypes.fs) attribute could be used to change serialization of enums.
-There are two [modes](src/FSharp.Json/InterfaceTypes.fs) supported currently: enum value name and enum value.
+EnumValue member of [JsonField](FSharp.Json/InterfaceTypes.fs) attribute could be used to change serialization of enums.
+There are two [modes](FSharp.Json/InterfaceTypes.fs) supported currently: enum value name and enum value.
 
 Here's an example of custom enum serialization:
 ```fsharp
@@ -480,7 +480,7 @@ let deserialized = Json.deserialize<TheUnion> json
 
 #### Changing union case key
 
-The string that represents union case key could be changed with [JsonUnionCase attribute](src/FSharp.Json/InterfaceTypes.fs).
+The string that represents union case key could be changed with [JsonUnionCase attribute](FSharp.Json/InterfaceTypes.fs).
 
 See the example below:
 
@@ -563,9 +563,9 @@ let deserialized = Json.deserialize<TheRecord> json
 
 #### Union modes
 
-There's [union mode](src/FSharp.Json/InterfaceTypes.fs) that represents union as JSON object with two fields.
+There's [union mode](FSharp.Json/InterfaceTypes.fs) that represents union as JSON object with two fields.
 One field is for case key and another one is for case value. This mode is called "case key as a field value"
-If this mode is used then names of these two field should be provided through [JsonUnion attribute](src/FSharp.Json/InterfaceTypes.fs).
+If this mode is used then names of these two field should be provided through [JsonUnion attribute](FSharp.Json/InterfaceTypes.fs).
 
 See the example below: 
 
@@ -595,17 +595,17 @@ What if some data needed to be represented as a different type then the default 
 If changing type of the member in F# is not an option then type transform can help.
 
 Any data member is translated F# Type -> JSON type by [default](supported-types) types mapping.
-[Type Transform](src/FSharp.Json/InterfaceTypes.fs) is applied in the middle of this translation: F# Type -> Alternative F# Type -> JSON type.
+[Type Transform](FSharp.Json/InterfaceTypes.fs) is applied in the middle of this translation: F# Type -> Alternative F# Type -> JSON type.
 Alternative F# Type -> JSON type is still done by default types mapping, type transform is responsible for F# Type -> Alternative F# Type.
 
-The [Transforms](src/FSharp.Json/Transforms.fs) module contains transforms that are defined by FSharp.Json library.
-You can define your own transforms by implementing [ITypeTransform interface](src/FSharp.Json/InterfaceTypes.fs).
+The [Transforms](FSharp.Json/Transforms.fs) module contains transforms that are defined by FSharp.Json library.
+You can define your own transforms by implementing [ITypeTransform interface](FSharp.Json/InterfaceTypes.fs).
 
 #### DateTime as epoch time
 
 Let's imagine that some DateTime member should be represented as [epoch time](https://en.wikipedia.org/wiki/Unix_time) in JSON.
 Epoch time is int64 however it is still convenient to work with DateTime in F# code.
-In such case [DateTimeEpoch transform](src/FSharp.Json/Transforms.fs) is useful.
+In such case [DateTimeEpoch transform](FSharp.Json/Transforms.fs) is useful.
 
 Here's an example of DateTimeEpoch transform usage:
 
@@ -660,7 +660,7 @@ To be developed....
 
 Using obj type in F# code is bad code smell.
 Though FSharp.Json can serialize and deserialize structures without type information.
-For allowing obj type in serialization/deserialization allowUntyped flag should be set to `true` on [JsonConfig](src/FSharp.Json/InterfaceTypes.fs).
+For allowing obj type in serialization/deserialization allowUntyped flag should be set to `true` on [JsonConfig](FSharp.Json/InterfaceTypes.fs).
 
 #### Serialization of obj
 


### PR DESCRIPTION
I guess the links broke with df7afd435122f7252d25fbd7e62aff22ad6a7135

So I tried to fix them to make navigating in the README easier again.