### PR TITLE
Handle null in untyped objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 bin
 obj
 *.DotSettings.user
+.ionide/

--- a/FSharp.Json.Tests/Object.fs
+++ b/FSharp.Json.Tests/Object.fs
@@ -15,3 +15,16 @@ module Object =
         let json = Json.serializeEx config expected
         let actual = Json.deserializeEx<ObjectRecord> config json
         Assert.AreEqual(expected, actual)
+
+    [<Test>]
+    let ``Object with null serialization/deserialization`` () =
+        let expectedMap =
+            Map.empty
+            |> Map.add "stringValue" ("The string" :> obj)
+            |> Map.add "intValue" (42M :> obj)
+            |> Map.add "nullValue" null
+        let expected = { ObjectRecord.value = expectedMap }
+        let config = JsonConfig.create(allowUntyped = true, unformatted = true)
+        let json = Json.serializeEx config expected
+        let actual = Json.deserializeEx<ObjectRecord> config json
+        Assert.AreEqual(expected, actual)

--- a/FSharp.Json/Core.fs
+++ b/FSharp.Json/Core.fs
@@ -208,7 +208,10 @@ module internal Core =
                 |> Seq.map (fun kvp ->
                     let key = KvpKey kvp :?> string
                     let value = KvpValue kvp
-                    let jvalue = serializeUnwrapOption (value.GetType()) JsonField.Default value
+                    let jvalue =
+                        match value with
+                        | null -> None
+                        | value -> serializeUnwrapOption (value.GetType()) JsonField.Default value
                     (key, Option.defaultValue JsonValue.Null jvalue)
                 )
             props|> Array.ofSeq |> JsonValue.Record
@@ -325,6 +328,8 @@ module internal Core =
                 let t = getUntypedType path t jvalue
                 let jvalue =
                     match t with
+                    | t when isNull t ->
+                        null :> obj
                     | t when t = typeof<int16> ->
                         JsonValueHelpers.getInt16 path jvalue :> obj
                     | t when t = typeof<uint16> ->


### PR DESCRIPTION
Null is a very annoying thing but I encountered a problem with it with the following json:
```
[
  [
    "English",
    {
      "windows":[
        {
          "manualUrl":"\/downloads\/mdk\/en1installer0",
          "name":"MDK",
          "version":"1.0",
          "date":"",
          "size":"173 MB"
        }
      ],
      "mac":[
        {
          "manualUrl":"\/downloads\/mdk\/en2installer0",
          "name":"MDK",
          "version":null,
          "date":"",
          "size":"132 MB"
        }
      ]
    }
  ]
]
```
Because of the list formatting (first entry string, second one an object) I am using `obj list list` with untyped setting to deserialize it and transform it to a usable structure. But the deserialization is failing because of the (potential) null in the version field.

I therefore added a test, which checks, if FSharp.Json can serialize and deserialize such an object and tried to implement support for it.

All tests run successfully on my machine after these changes.

I hope everything is okay with this PR, please tell me if I should change something :)