### PR TITLE
Allow more than 2 JSON fields in union key-value deserialization

### DIFF
--- a/FSharp.Json.Tests/Union.fs
+++ b/FSharp.Json.Tests/Union.fs
@@ -104,6 +104,13 @@ module Union =
         Assert.AreEqual(expected, actual)
 
     [<Test>]
+    let ``Union key-value deserialization (more than 2 fields)`` () =
+        let expected = TheAnnotatedUnion.StringCase "The string"
+        let json = """{"casekey":"StringCase","casevalue":"The string","unrelated_property":"unrelated_value"}"""
+        let actual = Json.deserialize<TheAnnotatedUnion> json
+        Assert.AreEqual(expected, actual)
+
+    [<Test>]
     let ``Union cases serialization with snake case naming`` () =
         let value = OneFieldCase "The string"
         let config = JsonConfig.create(unformatted = true, jsonFieldNaming = Json.snakeCase)

--- a/FSharp.Json/Core.fs
+++ b/FSharp.Json/Core.fs
@@ -498,8 +498,8 @@ module internal Core =
                                 failDeserialization path <| sprintf "Failed to parse union from record with %i fields, should be 1 field." fields.Length
                             fields.[0]
                         | UnionMode.CaseKeyAsFieldValue ->
-                            if fields.Length <> 2 then
-                                failDeserialization path <| sprintf "Failed to parse union from record with %i fields, should be 2 fields." fields.Length
+                            if fields.Length < 2 then
+                                failDeserialization path <| sprintf "Failed to parse union from record with %i fields, should be at least 2 fields." fields.Length
                             let caseKeyField = fields |> Seq.tryFind (fun f -> fst f = jsonUnion.CaseKeyField)
                             let caseKeyField =
                                 match caseKeyField with


### PR DESCRIPTION
Allow more than 2 JSON fields in union key-value deserialization.

https://github.com/vsapronov/FSharp.Json/issues/41