### PR TITLE
Support for null values during serialization

### DIFF
--- a/FSharp.Json.Tests/Map.fs
+++ b/FSharp.Json.Tests/Map.fs
@@ -32,3 +32,10 @@ module Map =
         let config = JsonConfig.create(allowUntyped = true)
         let actual = Json.deserializeEx<Map<string, obj>> config json
         Assert.AreEqual(expected, actual)
+
+    [<Test>]
+    let ``Map<string,null> serialization`` () =
+        let expected = """{"key1":[null],"key2":null}"""
+        let value = Map.ofList [("key1", [()] :> obj); ("key2", null)]
+        let actual = Json.serializeU value
+        Assert.AreEqual(expected, actual)

--- a/FSharp.Json/Reflection.fs
+++ b/FSharp.Json/Reflection.fs
@@ -18,6 +18,11 @@ module internal Reflection =
     let isList_ (t: Type) =
         t.IsGenericType && t.GetGenericTypeDefinition() = typedefof<List<_>>
 
+    let getType (o: obj) =
+        match o with
+        | null -> typeof<unit>
+        | _ -> o.GetType()
+
     let getListType_ (itemType: Type) =
         typedefof<List<_>>.MakeGenericType([| itemType |])
 


### PR DESCRIPTION
Fixed System.NullReferenceException when serializing null objects.
Issues https://github.com/vsapronov/FSharp.Json/issues/54 and https://github.com/vsapronov/FSharp.Json/issues/43