### PR TITLE
Performance optimisations: Using more value-types and structs

### DIFF
--- a/FSharp.Json/Core.fs
+++ b/FSharp.Json/Core.fs
@@ -78,13 +78,13 @@ module internal Core =
         match enumMode with
         | EnumMode.Value ->
             match baseT with
-            | t when t = typeof<int> ->
+            | t when Type.(=)(t, typeof<int>) ->
                 let enumValue = decimal (value :?> int)
                 JsonValue.Number enumValue
-            | t when t = typeof<byte> ->
+            | t when Type.(=)(t, typeof<byte>) ->
                 let enumValue = decimal (value :?> byte)
                 JsonValue.Number enumValue
-            | t when t = typeof<char> ->
+            | t when Type.(=)(t, typeof<char>) ->
                 let enumValue = sprintf "%c" (value :?> char)
                 JsonValue.String enumValue
         | EnumMode.Name ->
@@ -108,43 +108,43 @@ module internal Core =
                 let t, value = transformToTargetType t value jsonField.Transform
                 let t = getUntypedType config t value
                 match t with
-                | t when t = typeof<unit> ->
+                | t when Type.(=)(t, typeof<unit>) ->
                     JsonValue.Null
-                | t when t = typeof<uint16> ->
+                | t when Type.(=)(t, typeof<uint16>) ->
                     JsonValue.Number (decimal (value :?> uint16))
-                | t when t = typeof<int16> ->
+                | t when Type.(=)(t, typeof<int16>) ->
                     JsonValue.Number (decimal (value :?> int16))
-                | t when t = typeof<int> ->
+                | t when Type.(=)(t, typeof<int>) ->
                     JsonValue.Number (decimal (value :?> int))
-                | t when t = typeof<uint32> ->
+                | t when Type.(=)(t, typeof<uint32>) ->
                     JsonValue.Number (decimal (value :?> uint32))
-                | t when t = typeof<int64> ->
+                | t when Type.(=)(t, typeof<int64>) ->
                     JsonValue.Number (decimal (value :?> int64))
-                | t when t = typeof<uint64> ->
+                | t when Type.(=)(t, typeof<uint64>) ->
                     JsonValue.Number (decimal (value :?> uint64))
-                | t when t = typeof<bigint> ->
+                | t when Type.(=)(t, typeof<bigint>) ->
                     JsonValue.Number (decimal (value :?> bigint))
-                | t when t = typeof<single> ->
+                | t when Type.(=)(t, typeof<single>) ->
                     JsonValue.Float (float (value :?> single))
-                | t when t = typeof<float> ->
+                | t when Type.(=)(t, typeof<float>) ->
                     JsonValue.Float (value :?> float)
-                | t when t = typeof<decimal> ->
+                | t when Type.(=)(t, typeof<decimal>) ->
                     JsonValue.Number (value :?> decimal)
-                | t when t = typeof<byte> ->
+                | t when Type.(=)(t, typeof<byte>) ->
                     JsonValue.Number (decimal (value :?> byte))
-                | t when t = typeof<sbyte> ->
+                | t when Type.(=)(t, typeof<sbyte>) ->
                     JsonValue.Number (decimal (value :?> sbyte))
-                | t when t = typeof<bool> ->
+                | t when Type.(=)(t, typeof<bool>) ->
                     JsonValue.Boolean (value :?> bool)
-                | t when t = typeof<string> ->
+                | t when Type.(=)(t, typeof<string>) ->
                     JsonValue.String (value :?> string)
-                | t when t = typeof<char> ->
+                | t when Type.(=)(t, typeof<char>) ->
                     JsonValue.String (string(value :?> char))
-                | t when t = typeof<DateTime> ->
+                | t when Type.(=)(t, typeof<DateTime>) ->
                     JsonValue.String ((value :?> DateTime).ToString(jsonField.DateTimeFormat))
-                | t when t = typeof<DateTimeOffset> ->
+                | t when Type.(=)(t, typeof<DateTimeOffset>) ->
                     JsonValue.String ((value :?> DateTimeOffset).ToString(jsonField.DateTimeFormat))
-                | t when t = typeof<Guid> ->
+                | t when Type.(=)(t, typeof<Guid>) ->
                     JsonValue.String ((value :?> Guid).ToString())
                 | t when t.IsEnum ->
                     serializeEnum config t jsonField value
@@ -318,7 +318,7 @@ module internal Core =
 
         let getUntypedType (path: JsonPath) (t: Type) (jvalue: JsonValue): Type =
             match t with
-            | t when t = typeof<obj> ->
+            | t when Type.(=)(t, typeof<obj>) ->
                 if config.allowUntyped then
                     getJsonValueType jvalue
                 else
@@ -336,76 +336,76 @@ module internal Core =
                 let t = getUntypedType path t jvalue
                 let jvalue =
                     match t with
-                    | t when t = typeof<int16> ->
+                    | t when Type.(=)(t, typeof<int16>) ->
                         match jvalue with
                         | JsonValueHelpers.GetInt16 v -> v :> obj
                         | _ -> JsonValueHelpers.raiseWrongType path "int16" jvalue
-                    | t when t = typeof<uint16> ->
+                    | t when Type.(=)(t, typeof<uint16>) ->
                         match jvalue with
                         | JsonValueHelpers.GetUInt16 v -> v :> obj
                         | _ -> JsonValueHelpers.raiseWrongType path "uint16" jvalue
-                    | t when t = typeof<int> ->
+                    | t when Type.(=)(t, typeof<int>) ->
                         match jvalue with
                         | JsonValueHelpers.GetInt v -> v :> obj
                         | _ -> JsonValueHelpers.raiseWrongType path "int" jvalue
-                    | t when t = typeof<uint32> ->
+                    | t when Type.(=)(t, typeof<uint32>) ->
                         match jvalue with
                         | JsonValueHelpers.GetUInt32 v -> v :> obj
                         | _ -> JsonValueHelpers.raiseWrongType path "uint32" jvalue
-                    | t when t = typeof<int64> ->
+                    | t when Type.(=)(t, typeof<int64>) ->
                         match jvalue with
                         | JsonValueHelpers.GetInt64 v -> v :> obj
                         | _ -> JsonValueHelpers.raiseWrongType path "int64" jvalue
-                    | t when t = typeof<uint64> ->
+                    | t when Type.(=)(t, typeof<uint64>) ->
                         match jvalue with
                         | JsonValueHelpers.GetUInt64 v -> v :> obj
                         | _ -> JsonValueHelpers.raiseWrongType path "uint64" jvalue
-                    | t when t = typeof<bigint> ->
+                    | t when Type.(=)(t, typeof<bigint>) ->
                         match jvalue with
                         | JsonValueHelpers.GetBigint v -> v :> obj
                         | _ -> JsonValueHelpers.raiseWrongType path "bigint" jvalue
-                    | t when t = typeof<single> ->
+                    | t when Type.(=)(t, typeof<single>) ->
                         match jvalue with
                         | JsonValueHelpers.GetSingle v -> v :> obj
                         | _ -> JsonValueHelpers.raiseWrongType path "single" jvalue
-                    | t when t = typeof<float> ->
+                    | t when Type.(=)(t, typeof<float>) ->
                         match jvalue with
                         | JsonValueHelpers.GetFloat v -> v :> obj
                         | _ -> JsonValueHelpers.raiseWrongType path "float" jvalue
-                    | t when t = typeof<decimal> ->
+                    | t when Type.(=)(t, typeof<decimal>) ->
                         match jvalue with
                         | JsonValueHelpers.GetDecimal v -> v :> obj
                         | _ -> JsonValueHelpers.raiseWrongType path "decimal" jvalue
-                    | t when t = typeof<byte> ->
+                    | t when Type.(=)(t, typeof<byte>) ->
                         match jvalue with
                         | JsonValueHelpers.GetByte v -> v :> obj
                         | _ -> JsonValueHelpers.raiseWrongType path "byte" jvalue
-                    | t when t = typeof<sbyte> ->
+                    | t when Type.(=)(t, typeof<sbyte>) ->
                         match jvalue with
                         | JsonValueHelpers.GetSByte v -> v :> obj
                         | _ -> JsonValueHelpers.raiseWrongType path "sbyte" jvalue
-                    | t when t = typeof<bool> ->
+                    | t when Type.(=)(t, typeof<bool>) ->
                         match jvalue with
                         | JsonValueHelpers.GetBool v -> v :> obj
                         | _ -> JsonValueHelpers.raiseWrongType path "bool" jvalue
-                    | t when t = typeof<string> ->
+                    | t when Type.(=)(t, typeof<string>) ->
                         match jvalue with
                         | JsonValueHelpers.GetString v -> v :> obj
                         | _ -> JsonValueHelpers.raiseWrongType path "string" jvalue
-                    | t when t = typeof<char> ->
+                    | t when Type.(=)(t, typeof<char>) ->
                         match jvalue with
                         | JsonValueHelpers.GetChar v -> v :> obj
                         | JsonValueHelpers.GetString v when v.Length > 1 -> raise(JsonDeserializationError(path, sprintf "Expected string with single character, got jvalue: %s" v))
                         | _ -> JsonValueHelpers.raiseWrongType path "char" jvalue
-                    | t when t = typeof<DateTime> ->
+                    | t when Type.(=)(t, typeof<DateTime>) ->
                         match jvalue with
                         | JsonValueHelpers.GetDateTime CultureInfo.InvariantCulture v -> v :> obj
                         | _ -> JsonValueHelpers.raiseWrongType path "DateTime" jvalue
-                    | t when t = typeof<DateTimeOffset> ->
+                    | t when Type.(=)(t, typeof<DateTimeOffset>) ->
                         match jvalue with
                         | JsonValueHelpers.GetDateTimeOffset CultureInfo.InvariantCulture v -> v :> obj
                         | _ -> JsonValueHelpers.raiseWrongType path "DateTimeOffset" jvalue
-                    | t when t = typeof<Guid> ->
+                    | t when Type.(=)(t, typeof<Guid>) ->
                         match jvalue with
                         | JsonValueHelpers.GetGuid v -> v :> obj
                         | _ -> JsonValueHelpers.raiseWrongType path "Guid" jvalue

--- a/FSharp.Json/FSharp.Json.fsproj
+++ b/FSharp.Json/FSharp.Json.fsproj
@@ -10,7 +10,10 @@
     <RepositoryUrl>https://github.com/vsapronov/FSharp.Json</RepositoryUrl>
     <Version>0.4.1</Version>
   </PropertyGroup>
-  
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
+    <Optimize>true</Optimize>
+    <Tailcalls>true</Tailcalls>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="TextConversions.fs" />
     <Compile Include="JsonValue.fs" />

--- a/FSharp.Json/InterfaceTypes.fs
+++ b/FSharp.Json/InterfaceTypes.fs
@@ -77,11 +77,12 @@ with
 
 
 /// Represents one item in [JsonPath]
+[<Struct>]
 type JsonPathItem =
     /// Field in JSON object.
-    | Field of string
+    | Field of field: string
     /// Item in JSON array.
-    | ArrayItem of int
+    | ArrayItem of itm: int
 
 /// Represents path in JSON structure
 type JsonPath = {
@@ -119,6 +120,7 @@ type JsonDeserializationError(path: JsonPath, message: string) =
     member e.Path = path
 
 /// Modes of serialization of option None value
+[<Struct>]
 type SerializeNone =
     /// Serialize None value as null in JSON.
     | Null
@@ -126,6 +128,7 @@ type SerializeNone =
     | Omit
 
 /// Modes of deserialization of option types
+[<Struct>]
 type DeserializeOption =
     /// Allow members with None value to be omitted in JSON.
     | AllowOmit

--- a/FSharp.Json/JsonValue.fs
+++ b/FSharp.Json/JsonValue.fs
@@ -212,7 +212,7 @@ type private JsonParser(jsonText:string, cultureInfo, tolerateErrors) =
                         elif d >= 'A' && d <= 'F' then int32 d - int32 'A' + 10
                         else failwith "hexdigit"
                     let unicodeChar (s:string) =
-                        if s.Length <> 4 then failwith "unicodeChar";
+                        if s.Length <> 4 then failwithf "unicodeChar (%s)" s;
                         char (hexdigit s.[0] * 4096 + hexdigit s.[1] * 256 + hexdigit s.[2] * 16 + hexdigit s.[3])
                     let ch = unicodeChar (s.Substring(i+2, 4))
                     buf.Append(ch) |> ignore
@@ -220,8 +220,8 @@ type private JsonParser(jsonText:string, cultureInfo, tolerateErrors) =
                 | 'U' ->
                     ensure(i+9 < s.Length)
                     let unicodeChar (s:string) =
-                        if s.Length <> 8 then failwith "unicodeChar";
-                        if s.[0..1] <> "00" then failwith "unicodeChar";
+                        if s.Length <> 8 then failwithf "unicodeChar (%s)" s;
+                        if s.[0..1] <> "00" then failwithf "unicodeChar (%s)" s;
                         UnicodeHelper.getUnicodeSurrogatePair <| System.UInt32.Parse(s, NumberStyles.HexNumber) 
                     let lead, trail = unicodeChar (s.Substring(i+2, 8))
                     buf.Append(lead) |> ignore
@@ -245,10 +245,10 @@ type private JsonParser(jsonText:string, cultureInfo, tolerateErrors) =
         let len = i - start
         let sub = s.Substring(start,len)
         match TextConversions.AsDecimal cultureInfo sub with
-        | Some x -> JsonValue.Number x
+        | ValueSome x -> JsonValue.Number x
         | _ ->
             match TextConversions.AsFloat [| |] (*useNoneForMissingValues*)false cultureInfo sub with
-            | Some x -> JsonValue.Float x
+            | ValueSome x -> JsonValue.Float x
             | _ -> throw()
 
     and parsePair() =

--- a/FSharp.Json/JsonValueHelpers.fs
+++ b/FSharp.Json/JsonValueHelpers.fs
@@ -8,124 +8,137 @@ module internal JsonValueHelpers =
     let raiseWrongType path typeName jvalue =
         raise(JsonDeserializationError(path, sprintf "Expected type %s is incompatible with jvalue: %A" typeName jvalue))
 
-    let getInt16 (path: JsonPath) (jvalue: JsonValue) =
+    [<return: Struct>]
+    let (|GetInt16|_|) (jvalue: JsonValue) =
         match jvalue with
-        | JsonValue.Number value -> int16 value
-        | JsonValue.Float value -> int16 value
-        | _ -> raiseWrongType path "int16" jvalue
+        | JsonValue.Number value -> ValueSome (int16 value)
+        | JsonValue.Float value -> ValueSome (int16 value)
+        | _ -> ValueNone
 
-    let getUInt16 (path: JsonPath) (jvalue: JsonValue) =
+    [<return: Struct>]
+    let (|GetUInt16|_|) (jvalue: JsonValue) =
         match jvalue with
-        | JsonValue.Number value -> uint16 value
-        | JsonValue.Float value -> uint16 value
-        | _ -> raiseWrongType path "uint16" jvalue
+        | JsonValue.Number value -> ValueSome (uint16 value)
+        | JsonValue.Float value -> ValueSome (uint16 value)
+        | _ -> ValueNone
         
-    let getInt (path: JsonPath) (jvalue: JsonValue) =
+    [<return: Struct>]
+    let (|GetInt|_|) (jvalue: JsonValue) =
         match jvalue with
-        | JsonValue.Number value -> int value
-        | JsonValue.Float value -> int value
-        | _ -> raiseWrongType path "int" jvalue
+        | JsonValue.Number value -> ValueSome (int value)
+        | JsonValue.Float value -> ValueSome (int value)
+        | _ -> ValueNone
 
-    let getUInt32 (path: JsonPath) (jvalue: JsonValue) =
+    [<return: Struct>]
+    let (|GetUInt32|_|) (jvalue: JsonValue) =
         match jvalue with
-        | JsonValue.Number value -> uint32 value
-        | JsonValue.Float value -> uint32 value
-        | _ -> raiseWrongType path "uint32" jvalue
+        | JsonValue.Number value -> ValueSome (uint32 value)
+        | JsonValue.Float value -> ValueSome (uint32 value)
+        | _ -> ValueNone
     
-    let getInt64 (path: JsonPath) (jvalue: JsonValue) =
+    [<return: Struct>]
+    let (|GetInt64|_|) (jvalue: JsonValue) =
         match jvalue with
-        | JsonValue.Number value -> int64 value
-        | JsonValue.Float value -> int64 value
-        | _ -> raiseWrongType path "int64" jvalue
+        | JsonValue.Number value -> ValueSome (int64 value)
+        | JsonValue.Float value -> ValueSome (int64 value)
+        | _ -> ValueNone
 
-    let getUInt64 (path: JsonPath) (jvalue: JsonValue) =
+    [<return: Struct>]
+    let (|GetUInt64|_|) (jvalue: JsonValue) =
         match jvalue with
-        | JsonValue.Number value -> uint64 value
-        | JsonValue.Float value -> uint64 value
-        | _ -> raiseWrongType path "uint64" jvalue
+        | JsonValue.Number value -> ValueSome (uint64 value)
+        | JsonValue.Float value -> ValueSome (uint64 value)
+        | _ -> ValueNone
 
-    let getBigint (path: JsonPath) (jvalue: JsonValue) =
+    [<return: Struct>]
+    let (|GetBigint|_|) (jvalue: JsonValue) =
         match jvalue with
-        | JsonValue.Number value -> bigint value
-        | JsonValue.Float value -> bigint value
-        | _ -> raiseWrongType path "bigint" jvalue
+        | JsonValue.Number value -> ValueSome (bigint value)
+        | JsonValue.Float value -> ValueSome (bigint value)
+        | _ -> ValueNone
 
-    let getSingle (path: JsonPath) (jvalue: JsonValue) =
+    [<return: Struct>]
+    let (|GetSingle|_|) (jvalue: JsonValue) =
         match jvalue with
-        | JsonValue.Float value -> single value
-        | JsonValue.Number value -> single value
-        | _ -> raiseWrongType path "single" jvalue
+        | JsonValue.Float value -> ValueSome (single value)
+        | JsonValue.Number value -> ValueSome (single value)
+        | _ -> ValueNone
     
-    let getFloat (path: JsonPath) (jvalue: JsonValue) =
+    [<return: Struct>]
+    let (|GetFloat|_|) (jvalue: JsonValue) =
         match jvalue with
-        | JsonValue.Float value -> value
-        | JsonValue.Number value -> float value
-        | _ -> raiseWrongType path "float" jvalue
+        | JsonValue.Float value -> ValueSome value
+        | JsonValue.Number value -> ValueSome (float value)
+        | _ -> ValueNone
 
-    let getDecimal (path: JsonPath) (jvalue: JsonValue) =
+    [<return: Struct>]
+    let (|GetDecimal|_|) (jvalue: JsonValue) =
         match jvalue with
-        | JsonValue.Number value -> value
-        | JsonValue.Float value -> decimal value
-        | _ -> raiseWrongType path "decimal" jvalue
+        | JsonValue.Number value -> ValueSome value
+        | JsonValue.Float value -> ValueSome (decimal value)
+        | _ -> ValueNone
 
-    let getByte (path: JsonPath) (jvalue: JsonValue) =
+    [<return: Struct>]
+    let (|GetByte|_|) (jvalue: JsonValue) =
         match jvalue with
-        | JsonValue.Number value -> byte value
-        | JsonValue.Float value -> byte value
-        | _ -> raiseWrongType path "byte" jvalue
+        | JsonValue.Number value -> ValueSome (byte value)
+        | JsonValue.Float value -> ValueSome (byte value)
+        | _ -> ValueNone
 
-    let getSByte (path: JsonPath) (jvalue: JsonValue) =
+    [<return: Struct>]
+    let (|GetSByte|_|) (jvalue: JsonValue) =
         match jvalue with
-        | JsonValue.Number value -> sbyte value
-        | JsonValue.Float value -> sbyte value
-        | _ -> raiseWrongType path "sbyte" jvalue
+        | JsonValue.Number value -> ValueSome (sbyte value)
+        | JsonValue.Float value -> ValueSome (sbyte value)
+        | _ -> ValueNone
     
-    let getBool (path: JsonPath) (jvalue: JsonValue) =
+    [<return: Struct>]
+    let (|GetBool|_|) (jvalue: JsonValue) =
         match jvalue with
-        | JsonValue.Boolean value -> value
-        | _ -> raiseWrongType path "bool" jvalue
+        | JsonValue.Boolean value -> ValueSome value
+        | _ -> ValueNone
 
-    let getString (path: JsonPath) (jvalue: JsonValue) =
+    [<return: Struct>]
+    let (|GetString|_|) (jvalue: JsonValue) =
         match jvalue with
-        | JsonValue.String value -> value
-        | _ -> raiseWrongType path "string" jvalue
+        | JsonValue.String value -> ValueSome value
+        | _ -> ValueNone
 
-    let getChar (path: JsonPath) (jvalue: JsonValue) =
+    [<return: Struct>]
+    let (|GetChar|_|) (jvalue: JsonValue) =
         match jvalue with
         | JsonValue.String value ->
             match value.Length with
-            | 1 -> value.Chars(0)
-            | _ -> raise(JsonDeserializationError(path, sprintf "Expected string with single character, got jvalue: %s" value))
-        | _ -> raiseWrongType path "char" jvalue
+            | 1 -> ValueSome (value.Chars 0)
+            | _ -> ValueNone
+        | _ -> ValueNone
 
-    let getDateTime cultureInfo (path: JsonPath) (jvalue: JsonValue) =
+    [<return: Struct>]
+    let (|GetDateTime|_|) cultureInfo (jvalue: JsonValue) =
         match jvalue with
         | JsonValue.String value -> 
             let jvalue = TextConversions.AsDateTime cultureInfo value
-            match jvalue with
-            | Some jvalue -> jvalue
-            | None -> raiseWrongType path "DateTime" jvalue
-        | _ -> raiseWrongType path "DateTime" jvalue
+            jvalue
+        | _ -> ValueNone
 
-    let getDateTimeOffset cultureInfo (path: JsonPath) (jvalue: JsonValue) =
+    [<return: Struct>]
+    let (|GetDateTimeOffset|_|) cultureInfo (jvalue: JsonValue) =
         match jvalue with
         | JsonValue.String value -> 
             let jvalue = AsDateTimeOffset cultureInfo value
-            match jvalue with
-            | Some jvalue -> jvalue
-            | None -> raiseWrongType path "DateTimeOffset" jvalue
-        | _ -> raiseWrongType path "DateTimeOffset" jvalue
+            jvalue
+        | _ -> ValueNone
 
-    let getGuid (path: JsonPath) (jvalue: JsonValue) =
+    [<return: Struct>]
+    let (|GetGuid|_|) (jvalue: JsonValue) =
         match jvalue with
         | JsonValue.String value -> 
             let jvalue = TextConversions.AsGuid value
-            match jvalue with
-            | Some jvalue -> jvalue
-            | None -> raiseWrongType path "Guid" jvalue
-        | _ -> raiseWrongType path "Guid" jvalue
+            jvalue
+        | _ -> ValueNone
 
-    let getArray (path: JsonPath) (jvalue: JsonValue) =
+    [<return: Struct>]
+    let (|GetArray|_|) (jvalue: JsonValue) =
         match jvalue with
-        | JsonValue.Array arr -> arr
-        | _ -> raiseWrongType path "array" jvalue
+        | JsonValue.Array arr -> ValueSome arr
+        | _ -> ValueNone

--- a/FSharp.Json/Reflection.fs
+++ b/FSharp.Json/Reflection.fs
@@ -77,11 +77,11 @@ module internal Reflection =
     let getMapValueType: Type -> Type = getMapValueType_ |> cacheResult
     let getMapKvpTupleType: Type -> Type = getMapKvpTupleType_ |> cacheResult
 
-    let unwrapOption (t: Type) (value: obj): obj option =
+    let unwrapOption (t: Type) (value: obj): obj voption =
         let _, fields = FSharpValue.GetUnionFields(value, t)
         match fields.Length with
-        | 1 -> Some fields.[0]
-        | _ -> None
+        | 1 -> ValueSome fields.[0]
+        | _ -> ValueNone
 
     let optionNone (t: Type): obj =
         let casesInfos = getUnionCases t

--- a/FSharp.Json/Utils.fs
+++ b/FSharp.Json/Utils.fs
@@ -8,5 +8,5 @@ module internal Conversions =
         // Parse ISO 8601 format, fixing time zone if needed 
         let dateTimeStyles = DateTimeStyles.AllowWhiteSpaces ||| DateTimeStyles.RoundtripKind ||| DateTimeStyles.AssumeUniversal 
         match DateTimeOffset.TryParse(text, cultureInfo, dateTimeStyles) with 
-        | true, d -> Some d 
-        | _ -> None 
+        | true, d -> ValueSome d 
+        | _ -> ValueNone 


### PR DESCRIPTION
This commit reduces the memory usage and speeds up all the serialization.

I used also the benchmark-branch all the test that did have result for FSharp.Json,
to run test between the current version and this commit, both run with latest FSharp.Core. 
Here are the results:

```
BenchmarkDotNet=v0.11.5, OS=Windows 10.0.22621
13th Gen Intel Core i9-13900H, 1 CPU, 20 logical and 14 physical cores
.NET Core SDK=8.0.100-rc.1.23463.5
  [Host]     : .NET Core 2.0.9 (CoreCLR 4.6.26614.01, CoreFX 4.6.26614.01), 64bit RyuJIT DEBUG
  DefaultJob : .NET Core 2.0.9 (CoreCLR 4.6.26614.01, CoreFX 4.6.26614.01), 64bit RyuJIT
```
  
  
1. BoxedArrayRoundtrip


|          Method |      Mean |     Error |    StdDev |  Gen 0 |  Gen 1 | Gen 2 | Allocated | Version |
|---------------- |----------:|----------:|----------:|-------:|-------:|------:|----------:| -------:|
| Newtonsoft.Json |  3.680 us | 0.0302 us | 0.0282 us | 2.2736 | 0.0076 |     - |     14 KB | 13.0.3  |
|     FSharp.Json | 12.753 us | 0.1331 us | 0.1180 us | 1.9531 | 0.0153 |     - |  12.12 KB | 0.4.1   |
|     FSharp.Json | 12.187 us | 0.1455 us | 0.1361 us | 1.8311 | 0.0153 |     - |  11.41 KB | This PR | 


5. FSharpBinaryRoundtrip

|          Method |      Mean |     Error |    StdDev |     Gen 0 |    Gen 1 |    Gen 2 | Allocated | Version |
|---------------- |----------:|----------:|----------:|----------:|---------:|---------:|----------:| -------:|
| Newtonsoft.Json |  21.00 ms | 0.3417 ms | 0.3196 ms | 3156.25 | 968.75 | 375.0000 |  18.47 MB | 13.0.3  |
|     FSharp.Json | 120.64 ms | 2.3876 ms | 2.7495 ms | 6600.00 | 200.00 |        - |  40.88 MB | 0.4.1 |
|     FSharp.Json | 107.32 ms | 1.5377 ms | 1.4384 ms | 6000.00 | 200.00 |        - |  37.29 MB | This PR | 


6. FSharpListRoundtrip

|          Method |       Mean |     Error |    StdDev |    Gen 0 |   Gen 1 | Gen 2 | Allocated | Version |
|---------------- |-----------:|----------:|----------:|---------:|--------:|------:|----------:| -------:|
| Newtonsoft.Json | 111.8 us |  1.560 us |  1.459 us |  15.7471 |  0.7324 |     - |  97.62 KB | 13.0.3  |
|     FSharp.Json | 1,012.4 us | 12.436 us | 11.632 us | 138.6719 | 21.4844 |     - | 869.35 KB | 0.4.1 |
|     FSharp.Json | 997.4 us | 11.905 us | 10.553 us | 126.9531 | 19.5313 |     - | 798.89 KB | This PR | 


11. LargeTupleRoundtrip

|          Method |      Mean |     Error |    StdDev |  Gen 0 |  Gen 1 | Gen 2 | Allocated | Version |
|---------------- |----------:|----------:|----------:|-------:|-------:|------:|----------:| -------:|
| Newtonsoft.Json |  7.808 us | 0.0958 us | 0.0896 us | 2.6703 | 0.0305 |     - |  16.59 KB | 13.0.3  |
|     FSharp.Json | 27.109 us | 0.3354 us | 0.3137 us | 3.3569 | 0.0305 |     - |  20.82 KB | 0.4.1 |
|     FSharp.Json | 26.810 us | 0.5355 us | 0.9656 us | 3.1433 | 0.0305 |     - |  19.59 KB | This PR | 
