### PR TITLE
Re-implement perf-optimization

### DIFF
--- a/FSharp.Json/Core.fs
+++ b/FSharp.Json/Core.fs
@@ -79,13 +79,13 @@ module internal Core =
             match enumMode with
             | EnumMode.Value ->
                 match baseT with
-                | t when t = typeof<int> ->
+                | t when Type.(=)(t, typeof<int>) ->
                     let enumValue = decimal (value :?> int)
                     JsonValue.Number enumValue
-                | t when t = typeof<byte> ->
+                | t when Type.(=)(t, typeof<byte>) ->
                     let enumValue = decimal (value :?> byte)
                     JsonValue.Number enumValue
-                | t when t = typeof<char> ->
+                | t when Type.(=)(t, typeof<char>) ->
                     let enumValue = $"%c{value :?> char}"
                     JsonValue.String enumValue
             | EnumMode.Name ->
@@ -107,45 +107,45 @@ module internal Core =
                 let t, value = transformToTargetType t value jsonField.Transform
                 let t = getUntypedType t value
                 match t with
-                | t when t = typeof<unit> ->
+                | t when Type.(=)(t, typeof<unit>) ->
                     JsonValue.Null
-                | t when t = typeof<uint16> ->
+                | t when Type.(=)(t, typeof<uint16>) ->
                     JsonValue.Number (decimal (value :?> uint16))
-                | t when t = typeof<int16> ->
+                | t when Type.(=)(t, typeof<int16>) ->
                     JsonValue.Number (decimal (value :?> int16))
-                | t when t = typeof<int> ->
+                | t when Type.(=)(t, typeof<int>) ->
                     JsonValue.Number (decimal (value :?> int))
-                | t when t = typeof<uint32> ->
+                | t when Type.(=)(t, typeof<uint32>) ->
                     JsonValue.Number (decimal (value :?> uint32))
-                | t when t = typeof<int64> ->
+                | t when Type.(=)(t, typeof<int64>) ->
                     JsonValue.Number (decimal (value :?> int64))
-                | t when t = typeof<uint64> ->
+                | t when Type.(=)(t, typeof<uint64>) ->
                     JsonValue.Number (decimal (value :?> uint64))
-                | t when t = typeof<bigint> ->
+                | t when Type.(=)(t, typeof<bigint>) ->
                     JsonValue.Number (decimal (value :?> bigint))
-                | t when t = typeof<single> ->
+                | t when Type.(=)(t, typeof<single>) ->
                     JsonValue.Float (float (value :?> single))
-                | t when t = typeof<float> ->
+                | t when Type.(=)(t, typeof<float>) ->
                     JsonValue.Float (value :?> float)
-                | t when t = typeof<decimal> ->
+                | t when Type.(=)(t, typeof<decimal>) ->
                     JsonValue.Number (value :?> decimal)
-                | t when t = typeof<byte> ->
+                | t when Type.(=)(t, typeof<byte>) ->
                     JsonValue.Number (decimal (value :?> byte))
-                | t when t = typeof<sbyte> ->
+                | t when Type.(=)(t, typeof<sbyte>) ->
                     JsonValue.Number (decimal (value :?> sbyte))
-                | t when t = typeof<bool> ->
+                | t when Type.(=)(t, typeof<bool>) ->
                     JsonValue.Boolean (value :?> bool)
-                | t when t = typeof<string> ->
+                | t when Type.(=)(t, typeof<string>) ->
                     JsonValue.String (value :?> string)
-                | t when t = typeof<char> ->
+                | t when Type.(=)(t, typeof<char>) ->
                     JsonValue.String (string(value :?> char))
-                | t when t = typeof<DateTime> ->
+                | t when Type.(=)(t, typeof<DateTime>) ->
                     JsonValue.String ((value :?> DateTime).ToString(jsonField.DateTimeFormat))
-                | t when t = typeof<DateTimeOffset> ->
+                | t when Type.(=)(t, typeof<DateTimeOffset>) ->
                     JsonValue.String ((value :?> DateTimeOffset).ToString(jsonField.DateTimeFormat))
-                | t when t = typeof<TimeSpan> ->
+                | t when Type.(=)(t, typeof<TimeSpan>) ->
                     JsonValue.String ((value :?> TimeSpan).ToString())                    
-                | t when t = typeof<Guid> ->
+                | t when Type.(=)(t, typeof<Guid>) ->
                     JsonValue.String ((value :?> Guid).ToString())                                    
                 | t when t.IsEnum ->
                     serializeEnum t jsonField value
@@ -169,6 +169,14 @@ module internal Core =
                     match config.serializeNone with
                     | Null -> Some JsonValue.Null
                     | Omit -> None
+            |  t when isVOption t ->
+                let unwrapedValue = unwrapVOption t value
+                match unwrapedValue with
+                | ValueSome value -> Some (serializeNonOption (getOptionType t) jsonField value)
+                | ValueNone -> 
+                    match config.serializeNone with
+                    | Null -> Some JsonValue.Null
+                    | Omit -> None
             | _ -> Some (serializeNonOption t jsonField value)
 
         let serializeUnwrapOptionWithNull (t: Type) (jsonField: JsonField) (value: obj): JsonValue =
@@ -178,6 +186,11 @@ module internal Core =
                 match unwrapedValue with
                 | Some value -> serializeNonOption (getOptionType t) jsonField value
                 | None -> JsonValue.Null
+            |  t when isVOption t ->
+                let unwrapedValue = unwrapVOption t value
+                match unwrapedValue with
+                | ValueSome value -> serializeNonOption (getOptionType t) jsonField value
+                | ValueNone -> JsonValue.Null
             | _ -> serializeNonOption t jsonField value
 
         let serializeProperty (therec: obj) (prop: PropertyInfo): (string*JsonValue) option =
@@ -334,43 +347,43 @@ module internal Core =
                 let t = getUntypedType path t jValue
                 let jValue =
                     match t with
-                    | t when t = typeof<int16> ->
+                    | t when Type.(=)(t, typeof<int16>) ->
                         JsonValueHelpers.getInt16 path jValue :> obj
-                    | t when t = typeof<uint16> ->
+                    | t when Type.(=)(t, typeof<uint16>) ->
                         JsonValueHelpers.getUInt16 path jValue :> obj
-                    | t when t = typeof<int> ->
+                    | t when Type.(=)(t, typeof<int>) ->
                         JsonValueHelpers.getInt path jValue :> obj
-                    | t when t = typeof<uint32> ->
+                    | t when Type.(=)(t, typeof<uint32>) ->
                         JsonValueHelpers.getUInt32 path jValue :> obj
-                    | t when t = typeof<int64> ->
+                    | t when Type.(=)(t, typeof<int64>) ->
                         JsonValueHelpers.getInt64 path jValue :> obj
-                    | t when t = typeof<uint64> ->
+                    | t when Type.(=)(t, typeof<uint64>) ->
                         JsonValueHelpers.getUInt64 path jValue :> obj
-                    | t when t = typeof<bigint> ->
+                    | t when Type.(=)(t, typeof<bigint>) ->
                         JsonValueHelpers.getBigint path jValue :> obj
-                    | t when t = typeof<single> ->
+                    | t when Type.(=)(t, typeof<single>) ->
                         JsonValueHelpers.getSingle path jValue :> obj
-                    | t when t = typeof<float> ->
+                    | t when Type.(=)(t, typeof<float>) ->
                         JsonValueHelpers.getFloat path jValue :> obj
-                    | t when t = typeof<decimal> ->
+                    | t when Type.(=)(t, typeof<decimal>) ->
                         JsonValueHelpers.getDecimal path jValue :> obj
-                    | t when t = typeof<byte> ->
+                    | t when Type.(=)(t, typeof<byte>) ->
                         JsonValueHelpers.getByte path jValue :> obj
-                    | t when t = typeof<sbyte> ->
+                    | t when Type.(=)(t, typeof<sbyte>) ->
                         JsonValueHelpers.getSByte path jValue :> obj
-                    | t when t = typeof<bool> ->
+                    | t when Type.(=)(t, typeof<bool>) ->
                         JsonValueHelpers.getBool path jValue :> obj
-                    | t when t = typeof<string> ->
+                    | t when Type.(=)(t, typeof<string>) ->
                         JsonValueHelpers.getString path jValue :> obj
-                    | t when t = typeof<char> ->
+                    | t when Type.(=)(t, typeof<char>) ->
                         JsonValueHelpers.getChar path jValue :> obj
-                    | t when t = typeof<DateTime> ->
+                    | t when Type.(=)(t, typeof<DateTime>) ->
                         JsonValueHelpers.getDateTime CultureInfo.InvariantCulture path jValue :> obj
-                    | t when t = typeof<DateTimeOffset> ->
+                    | t when Type.(=)(t, typeof<DateTimeOffset>) ->
                         JsonValueHelpers.getDateTimeOffset CultureInfo.InvariantCulture path jValue :> obj
-                    | t when t = typeof<TimeSpan> ->
+                    | t when Type.(=)(t, typeof<TimeSpan>) ->
                         JsonValueHelpers.getTimeSpan path jValue :> obj                        
-                    | t when t = typeof<Guid> ->
+                    | t when Type.(=)(t, typeof<Guid>) ->
                         JsonValueHelpers.getGuid path jValue :> obj                                            
                     | t when t.IsEnum ->
                         deserializeEnum path t jsonField jValue
@@ -381,7 +394,7 @@ module internal Core =
 
         let deserializeUnwrapOption (path: JsonPath) (t: Type) (jsonField: JsonField) (jvalue: JsonValue option): obj =
             match t with
-            | t when isOption t ->
+            | t when isOption t || isVOption t ->
                 match jvalue with
                 | Some jvalue ->
                     match jvalue with

--- a/FSharp.Json/FSharp.Json.fsproj
+++ b/FSharp.Json/FSharp.Json.fsproj
@@ -10,7 +10,10 @@
     <RepositoryUrl>https://github.com/vsapronov/FSharp.Json</RepositoryUrl>
     <Version>0.4.1</Version>
   </PropertyGroup>
-  
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
+    <Optimize>true</Optimize>
+    <Tailcalls>true</Tailcalls>
+  </PropertyGroup>  
   <ItemGroup>
     <Compile Include="TextConversions.fs" />
     <Compile Include="JsonValue.fs" />

--- a/FSharp.Json/InterfaceTypes.fs
+++ b/FSharp.Json/InterfaceTypes.fs
@@ -77,11 +77,12 @@ with
 
 
 /// Represents one item in [JsonPath]
+[<Struct>]
 type JsonPathItem =
     /// Field in JSON object.
-    | Field of string
+    | Field of field: string
     /// Item in JSON array.
-    | ArrayItem of int
+    | ArrayItem of itm: int
 
 /// Represents path in JSON structure
 type JsonPath = {
@@ -119,6 +120,7 @@ type JsonDeserializationError(path: JsonPath, message: string) =
     member e.Path = path
 
 /// Modes of serialization of option None value
+[<Struct>]
 type SerializeNone =
     /// Serialize None value as null in JSON.
     | Null
@@ -126,6 +128,7 @@ type SerializeNone =
     | Omit
 
 /// Modes of deserialization of option types
+[<Struct>]
 type DeserializeOption =
     /// Allow members with None value to be omitted in JSON.
     | AllowOmit

--- a/FSharp.Json/JsonValue.fs
+++ b/FSharp.Json/JsonValue.fs
@@ -212,7 +212,7 @@ type private JsonParser(jsonText:string, cultureInfo, tolerateErrors) =
                         elif d >= 'A' && d <= 'F' then int32 d - int32 'A' + 10
                         else failwith "hexdigit"
                     let unicodeChar (s:string) =
-                        if s.Length <> 4 then failwith "unicodeChar";
+                        if s.Length <> 4 then failwithf "unicodeChar (%s)" s;
                         char (hexdigit s.[0] * 4096 + hexdigit s.[1] * 256 + hexdigit s.[2] * 16 + hexdigit s.[3])
                     let ch = unicodeChar (s.Substring(i+2, 4))
                     buf.Append(ch) |> ignore
@@ -220,8 +220,8 @@ type private JsonParser(jsonText:string, cultureInfo, tolerateErrors) =
                 | 'U' ->
                     ensure(i+9 < s.Length)
                     let unicodeChar (s:string) =
-                        if s.Length <> 8 then failwith "unicodeChar";
-                        if s.[0..1] <> "00" then failwith "unicodeChar";
+                        if s.Length <> 8 then failwithf "unicodeChar (%s)" s;
+                        if s.[0..1] <> "00" then failwithf "unicodeChar (%s)" s;
                         UnicodeHelper.getUnicodeSurrogatePair <| System.UInt32.Parse(s, NumberStyles.HexNumber) 
                     let lead, trail = unicodeChar (s.Substring(i+2, 8))
                     buf.Append(lead) |> ignore

--- a/FSharp.Json/JsonValueHelpers.fs
+++ b/FSharp.Json/JsonValueHelpers.fs
@@ -102,8 +102,8 @@ module internal JsonValueHelpers =
         | JsonValue.String value -> 
             let jValue = TextConversions.AsDateTime cultureInfo value
             match jValue with
-            | Some jValue -> jValue
-            | None -> raiseWrongType path "DateTime" jValue
+            | ValueSome jValue -> jValue
+            | ValueNone -> raiseWrongType path "DateTime" jValue
         | _ -> raiseWrongType path "DateTime" jValue
 
     let getDateTimeOffset cultureInfo (path: JsonPath) (jValue: JsonValue) =
@@ -111,8 +111,8 @@ module internal JsonValueHelpers =
         | JsonValue.String value -> 
             let jValue = AsDateTimeOffset cultureInfo value
             match jValue with
-            | Some jValue -> jValue
-            | None -> raiseWrongType path "DateTimeOffset" jValue
+            | ValueSome jValue -> jValue
+            | ValueNone -> raiseWrongType path "DateTimeOffset" jValue
         | _ -> raiseWrongType path "DateTimeOffset" jValue
 
     let getTimeSpan (path: JsonPath) (jValue: JsonValue) =

--- a/FSharp.Json/Reflection.fs
+++ b/FSharp.Json/Reflection.fs
@@ -9,6 +9,9 @@ module internal Reflection =
     let isOption_ (t: Type): bool =
         t.IsGenericType && t.GetGenericTypeDefinition() = typedefof<option<_>>
 
+    let isVOption_ (t: Type): bool =
+        t.IsGenericType && t.GetGenericTypeDefinition() = typedefof<voption<_>>
+
     let getOptionType_ (t: Type): Type =
         t.GetGenericArguments().[0]
 
@@ -62,6 +65,7 @@ module internal Reflection =
     let getTupleElements: Type -> Type [] = FSharpType.GetTupleElements |> cacheResult
 
     let isOption: Type -> bool = isOption_ |> cacheResult
+    let isVOption: Type -> bool = isOption_ |> cacheResult
     let getOptionType: Type -> Type = getOptionType_ |> cacheResult
 
     let isArray: Type -> bool = isArray_ |> cacheResult
@@ -82,6 +86,12 @@ module internal Reflection =
         match fields.Length with
         | 1 -> Some fields.[0]
         | _ -> None
+
+    let unwrapVOption (t: Type) (value: obj): obj voption =
+        let _, fields = FSharpValue.GetUnionFields(value, t)
+        match fields.Length with
+        | 1 -> ValueSome fields.[0]
+        | _ -> ValueNone
 
     let optionNone (t: Type): obj =
         let casesInfos = getUnionCases t

--- a/FSharp.Json/Utils.fs
+++ b/FSharp.Json/Utils.fs
@@ -8,5 +8,5 @@ module internal Conversions =
         // Parse ISO 8601 format, fixing time zone if needed 
         let dateTimeStyles = DateTimeStyles.AllowWhiteSpaces ||| DateTimeStyles.RoundtripKind ||| DateTimeStyles.AssumeUniversal 
         match DateTimeOffset.TryParse(text, cultureInfo, dateTimeStyles) with 
-        | true, d -> Some d 
-        | _ -> None 
+        | true, d -> ValueSome d 
+        | _ -> ValueNone 


### PR DESCRIPTION
This is re-implementation of #68 with little bit smaller change set this time.
All tests pass, but I don't know how good is the current test-coverage.

Meanwhile it's not magic, it does cut some execution time, here are the results from this PR https://github.com/dbarbashov/FSharp.Json/pull/1

BenchmarkDotNet v0.15.2, Windows 11 (10.0.26100.5074/24H2/2024Update/HudsonValley)
13th Gen Intel Core i9-13900H 2.60GHz, 1 CPU, 20 logical and 14 physical cores
.NET SDK 9.0.304
  [Host]     : .NET 9.0.8 (9.0.825.36511), X64 RyuJIT AVX2 DEBUG
  DefaultJob : .NET 9.0.8 (9.0.825.36511), X64 RyuJIT AVX2
  
  
1. BoxedArrayRoundtrip

| Method          | Mean     | Error     | StdDev    | Gen0   | Gen1   | Allocated | Version |
|---------------- |---------:|----------:|----------:|-------:|-------:|----------:|-------:|
| Newtonsoft.Json | 2.127 us | 0.0412 us | 0.0491 us | 0.8850 | 0.0114 |  10.86 KB | 13.0.1 |
| FSharp.Json     | 6.076 us | 0.0505 us | 0.0448 us | 0.9460 | 0.0076 |  11.63 KB | master |
| FSharp.Json     | 4.340 us | 0.0398 us | 0.0372 us | 0.9384 | 0.0076 |  11.53 KB | this-PR |
 
5. FSharpBinaryRoundtrip

| Method          | Mean     | Error    | StdDev   | Gen0      | Gen1     | Gen2     | Allocated | Version |
|---------------- |---------:|---------:|---------:|----------:|---------:|---------:|----------:|-------:|
| Newtonsoft.Json | 13.04 ms | 0.211 ms | 0.197 ms | 1484.3750 | 984.3750 | 125.0000 |  17.92 MB | 13.0.1 |
| FSharp.Json     | 49.42 ms | 0.461 ms | 0.408 ms | 2700.0000 | 500.0000 |        - |  33.27 MB | master |
| FSharp.Json     | 47.87 ms | 0.203 ms | 0.180 ms | 2800.0000 | 400.0000 |        - |  33.73 MB |this-PR |
 

6. FSharpListRoundtrip

| Method          | Mean      | Error    | StdDev   | Gen0    | Gen1    | Allocated | Version |
|---------------- |----------:|---------:|---------:|--------:|--------:|----------:|-------:|
| Newtonsoft.Json |  52.50 us | 1.002 us | 1.029 us |  7.9346 |  0.4883 |  97.55 KB | 13.0.1 |
| FSharp.Json     | 376.12 us | 3.696 us | 3.457 us | 64.9414 | 10.7422 |  798.8 KB | master |
| FSharp.Json     | 322.84 us | 2.010 us | 1.678 us | 63.4766 | 12.2070 | 783.17 KB | this-PR |
 

11. LargeTupleRoundtrip

| Method          | Mean      | Error     | StdDev    | Gen0   | Gen1   | Allocated | Version |
|---------------- |----------:|----------:|----------:|-------:|-------:|----------:|-------:|
| Newtonsoft.Json |  4.137 us | 0.0702 us | 0.0657 us | 1.0834 | 0.0229 |  13.29 KB | 13.0.1 |
| FSharp.Json     | 11.809 us | 0.2158 us | 0.1913 us | 1.5869 |      - |  19.82 KB | master |
| FSharp.Json     | 9.760 us | 0.1667 us | 0.1559 us | 1.5869 |      - |  19.63 KB | this-PR |
 



